### PR TITLE
feat: add PetKit dual-hopper support and schedule matrix card

### DIFF
--- a/rollup.config.prod.mjs
+++ b/rollup.config.prod.mjs
@@ -4,13 +4,25 @@ import nodeResolve from "@rollup/plugin-node-resolve";
 import css from "rollup-plugin-import-css";
 import json from "@rollup/plugin-json";
 
-export default {
-  input: "src/dispenser-schedule-card.ts",
-  output: [
-    {
-      file: "dist/dispenser-schedule-card.min.js",
-      plugins: [terser()],
-    },
-  ],
-  plugins: [nodeResolve({}), typescript(), css(), json()],
-};
+export default [
+  {
+    input: "src/dispenser-schedule-card.ts",
+    output: [
+      {
+        file: "dist/dispenser-schedule-card.min.js",
+        plugins: [terser()],
+      },
+    ],
+    plugins: [nodeResolve({}), typescript(), css(), json()],
+  },
+  {
+    input: "src/petkit-schedule-matrix-card.ts",
+    output: [
+      {
+        file: "dist/petkit-schedule-matrix-card.min.js",
+        plugins: [terser()],
+      },
+    ],
+    plugins: [nodeResolve({}), typescript(), css(), json()],
+  },
+];

--- a/src/devices/PetkitDevice.ts
+++ b/src/devices/PetkitDevice.ts
@@ -1,0 +1,242 @@
+import { Device, EntryStatus, ScheduleEntry, EditScheduleEntry } from "../types/common";
+import { DispenserScheduleCardConfig } from "../types/config";
+
+/**
+ * PetKit feeder device handler.
+ *
+ * Unlike the per-entry CRUD model used by ESPHome/Xiaomi devices, PetKit
+ * feeders require a _full 7-day schedule_ to be sent in every saveFeed API
+ * call. This device implementation:
+ *
+ *  1. Parses the sensor state string (id,hour,minute,amount,status)
+ *  2. Reads the full schedule from entity.attributes.feed_daily_list
+ *  3. On add/edit/remove, mutates the relevant day's items in-place
+ *  4. Calls petkit.set_feeding_schedule with the complete schedule
+ */
+
+interface PetkitDeviceConfig {
+  type: "petkit";
+  /** The PetKit device_id (integer) for the set_feeding_schedule service. */
+  device_id: number;
+}
+
+/** PetKit status code → card EntryStatus mapping. */
+const PETKIT_STATUS_MAP: Record<number, EntryStatus> = {
+  0: EntryStatus.PENDING,
+  1: EntryStatus.DISPENSED,
+  2: EntryStatus.DISPENSED,
+  3: EntryStatus.DISPENSED,
+  6: EntryStatus.SKIPPED,
+  7: EntryStatus.FAILED,
+  8: EntryStatus.SKIPPED,
+  9: EntryStatus.FAILED,
+};
+
+const SCHEDULE_REGEX =
+  /(?<id>[0-9]+),(?<hour>[0-9]{1,2}),(?<minute>[0-9]{1,2}),(?<amount>[0-9]+),(?<status>[0-9]+),?/g;
+
+export default class PetkitDevice extends Device {
+  readonly maxEntries = 10;
+  readonly maxAmount = 50;
+  readonly minAmount = 1;
+  readonly stepAmount = 1;
+
+  private deviceId: number;
+
+  get isDualHopper(): boolean {
+    return true;
+  }
+
+  constructor(
+    config: DispenserScheduleCardConfig<PetkitDeviceConfig>,
+    hass: any,
+  ) {
+    super(config, hass);
+    this.deviceId = config.device.device_id;
+  }
+
+  getSchedule(state: string): Array<ScheduleEntry> {
+    // Try to get per-hopper amounts from entity attributes
+    const entity = this.hass?.states?.[this.config.entity ?? ""];
+    const feedDailyList = entity?.attributes?.feed_daily_list;
+
+    // If we have per-hopper data from attributes, use it for day 1 (today)
+    if (feedDailyList && Array.isArray(feedDailyList) && feedDailyList.length > 0) {
+      return this._parseFromAttributes(feedDailyList[0], state);
+    }
+
+    // Fallback: parse state string (combined amounts only)
+    return this._parseFromState(state);
+  }
+
+  /**
+   * Parse schedule from entity attributes (first day), enriching with
+   * live status from the state string.
+   */
+  private _parseFromAttributes(
+    day: any,
+    state: string,
+  ): Array<ScheduleEntry> {
+    // Build a status lookup from the state string, keyed by "hour:minute"
+    const statusMap = new Map<string, EntryStatus>();
+    const regex = new RegExp(SCHEDULE_REGEX, "g");
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(state)) !== null) {
+      const h = parseInt(match.groups!.hour);
+      const m = parseInt(match.groups!.minute);
+      const s = parseInt(match.groups!.status);
+      statusMap.set(`${h}:${m}`, PETKIT_STATUS_MAP[s] ?? EntryStatus.PENDING);
+    }
+
+    const schedules: Array<ScheduleEntry> = [];
+    const items = day.items || [];
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      const timeSec = item.time ?? 0;
+      const hour = Math.floor(timeSec / 3600);
+      const minute = Math.floor((timeSec % 3600) / 60);
+      const a1 = item.amount1 ?? 0;
+      const a2 = item.amount2 ?? 0;
+
+      schedules.push({
+        id: i,
+        hour,
+        minute,
+        amount: a1 + a2,
+        amount1: a1,
+        amount2: a2,
+        status: statusMap.get(`${hour}:${minute}`) ?? EntryStatus.PENDING,
+      });
+    }
+
+    return schedules.sort((a, b) => a.hour - b.hour || a.minute - b.minute);
+  }
+
+  /**
+   * Fallback: parse sensor state string (no per-hopper info).
+   */
+  private _parseFromState(state: string): Array<ScheduleEntry> {
+    const schedules: Array<ScheduleEntry> = [];
+    const regex = new RegExp(SCHEDULE_REGEX, "g");
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(state)) !== null) {
+      schedules.push({
+        id: parseInt(match.groups!.id),
+        hour: parseInt(match.groups!.hour),
+        minute: parseInt(match.groups!.minute),
+        amount: parseInt(match.groups!.amount),
+        status: PETKIT_STATUS_MAP[parseInt(match.groups!.status)] ?? EntryStatus.PENDING,
+      });
+    }
+    return schedules.sort((a, b) => a.hour - b.hour || a.minute - b.minute);
+  }
+
+  /**
+   * Build the full feed_daily_list payload from the entity's attributes,
+   * applying the mutation (add/edit entry) identified by the card.
+   */
+  handleSave(
+    hass: any,
+    _schedules: Array<ScheduleEntry>,
+    entry: EditScheduleEntry,
+    scheduleEntity: any,
+  ): boolean {
+    const rawSchedule = scheduleEntity?.attributes?.feed_daily_list;
+    if (!rawSchedule || !Array.isArray(rawSchedule)) {
+      console.error("[PetkitDevice] No feed_daily_list in entity attributes");
+      return false;
+    }
+
+    // Deep clone to avoid mutating state
+    const feedDailyList: Array<any> = JSON.parse(JSON.stringify(rawSchedule));
+
+    const timeInSeconds = entry.hour * 3600 + entry.minute * 60;
+    const a1 = entry.amount1 ?? Math.ceil(entry.amount / 2);
+    const a2 = entry.amount2 ?? Math.floor(entry.amount / 2);
+
+    if (entry.id === null) {
+      // ADD: insert into every day's items (PetKit schedule repeats daily)
+      for (const day of feedDailyList) {
+        day.items.push({
+          time: timeInSeconds,
+          name: `Feed ${entry.hour}:${entry.minute.toString().padStart(2, "0")}`,
+          amount: null,
+          amount1: a1,
+          amount2: a2,
+          id: timeInSeconds,
+        });
+        day.count = day.items.length;
+      }
+    } else {
+      // EDIT: find entry by its index (id) in each day and update
+      for (const day of feedDailyList) {
+        const item = day.items[entry.id];
+        if (item) {
+          item.time = timeInSeconds;
+          item.id = timeInSeconds;
+          item.name = `Feed ${entry.hour}:${entry.minute.toString().padStart(2, "0")}`;
+          item.amount1 = a1;
+          item.amount2 = a2;
+          item.amount = null;
+        }
+      }
+    }
+
+    this._callSetSchedule(hass, feedDailyList);
+    return true;
+  }
+
+  /**
+   * Remove an entry from every day and call the bulk save.
+   */
+  handleRemove(
+    hass: any,
+    _schedules: Array<ScheduleEntry>,
+    entry: EditScheduleEntry,
+    scheduleEntity: any,
+  ): boolean {
+    if (entry.id === null) {
+      return false;
+    }
+
+    const rawSchedule = scheduleEntity?.attributes?.feed_daily_list;
+    if (!rawSchedule || !Array.isArray(rawSchedule)) {
+      console.error("[PetkitDevice] No feed_daily_list in entity attributes");
+      return false;
+    }
+
+    const feedDailyList: Array<any> = JSON.parse(JSON.stringify(rawSchedule));
+
+    for (const day of feedDailyList) {
+      if (entry.id < day.items.length) {
+        day.items.splice(entry.id, 1);
+        day.count = day.items.length;
+      }
+    }
+
+    this._callSetSchedule(hass, feedDailyList);
+    return true;
+  }
+
+  /**
+   * Call petkit.set_feeding_schedule with the full schedule payload.
+   */
+  private _callSetSchedule(hass: any, feedDailyList: Array<any>): void {
+    const serviceData = {
+      device_id: this.deviceId,
+      feed_daily_list: feedDailyList.map((day: any) => ({
+        repeats: day.repeats,
+        suspended: day.suspended ?? 0,
+        items: day.items.map((item: any) => ({
+          time: item.time,
+          name: item.name,
+          amount: item.amount ?? 0,
+          amount1: item.amount1 ?? 0,
+          amount2: item.amount2 ?? 0,
+        })),
+      })),
+    };
+
+    hass.callService("petkit", "set_feeding_schedule", serviceData);
+  }
+}

--- a/src/devices/index.ts
+++ b/src/devices/index.ts
@@ -1,8 +1,10 @@
 import CustomDevice from "./CustomDevice";
+import PetkitDevice from "./PetkitDevice";
 import XiaomiSmartFeeder from "./XiaomiSmartFeeder";
 
 const Devices = {
   "custom": CustomDevice,
+  "petkit": PetkitDevice,
   "xiaomi-smart-feeder": XiaomiSmartFeeder,
 } as const;
 export type DeviceType = keyof typeof Devices;

--- a/src/dispenser-schedule-card.ts
+++ b/src/dispenser-schedule-card.ts
@@ -96,7 +96,11 @@ class DispenserScheduleCard extends LitElement {
   }
 
   handleEditEntry(entry: ScheduleEntry) {
-    this._editSchedule = entry;
+    this._editSchedule = {
+      ...entry,
+      amount1: entry.amount1,
+      amount2: entry.amount2,
+    };
   }
 
   handleAddEntry() {
@@ -104,12 +108,18 @@ class DispenserScheduleCard extends LitElement {
       id: null,
       hour: 0,
       minute: 0,
-      amount: this._device.minAmount,
+      amount: this._device.minAmount * (this._device.isDualHopper ? 2 : 1),
+      amount1: this._device.isDualHopper ? this._device.minAmount : undefined,
+      amount2: this._device.isDualHopper ? this._device.minAmount : undefined,
     };
   }
 
   handleRemoveEntry(entry: EditScheduleEntry) {
     if (entry.id === null || !this._config.actions?.remove) {
+      return;
+    }
+    // Delegate to device-specific handler (e.g. PetKit bulk-replace)
+    if (this._device.handleRemove(this._hass, this._schedules, entry, this._scheduleEntity)) {
       return;
     }
     const [domain, action] = this._config.actions.remove.split(".");
@@ -135,6 +145,12 @@ class DispenserScheduleCard extends LitElement {
   handleSaveEntry() {
     const entry = this._editSchedule;
     if (!entry) {
+      return;
+    }
+
+    // Delegate to device-specific handler (e.g. PetKit bulk-replace)
+    if (this._device.handleSave(this._hass, this._schedules, entry, this._scheduleEntity)) {
+      this._editSchedule = null;
       return;
     }
 
@@ -206,8 +222,9 @@ class DispenserScheduleCard extends LitElement {
     return status;
   }
 
-  renderAmount(amount: number) {
+  renderAmount(entry: ScheduleEntry | EditScheduleEntry) {
     const { alternate_unit } = this._config;
+    const amount = entry.amount;
 
     let pluralCategory: Intl.LDMLPluralRule = "other";
     try {
@@ -226,7 +243,14 @@ class DispenserScheduleCard extends LitElement {
     } else {
       main_unit = localize(`ui.portions_${pluralCategory}`) ?? "portions";
     }
-    const mainStr = `${amount} ${main_unit}`;
+
+    // Dual-hopper: show per-hopper breakdown
+    let mainStr: string;
+    if (this._device.isDualHopper && entry.amount1 != null && entry.amount2 != null) {
+      mainStr = `H1: ${entry.amount1} | H2: ${entry.amount2} ${main_unit}`;
+    } else {
+      mainStr = `${amount} ${main_unit}`;
+    }
 
     let alternateStr;
     if (alternate_unit) {
@@ -263,7 +287,7 @@ class DispenserScheduleCard extends LitElement {
 
     const label = display.label ?? displayStatus;
     const statusText = localize(`status.${label}`) ?? label;
-    const secondaryText = this.renderAmount(amount);
+    const secondaryText = this.renderAmount(entry);
 
     const color =
       display?.color || DefaultDisplayConfig[displayStatus]?.color || undefined;
@@ -346,6 +370,18 @@ class DispenserScheduleCard extends LitElement {
   handleAmountChanged(ev: InputEvent, entry: EditScheduleEntry) {
     const amount = parseInt((ev.target as HTMLInputElement).value);
     this._editSchedule = { ...entry, amount };
+  }
+
+  handleAmount1Changed(ev: InputEvent, entry: EditScheduleEntry) {
+    const amount1 = parseInt((ev.target as HTMLInputElement).value);
+    const amount2 = entry.amount2 ?? 0;
+    this._editSchedule = { ...entry, amount1, amount: amount1 + amount2 };
+  }
+
+  handleAmount2Changed(ev: InputEvent, entry: EditScheduleEntry) {
+    const amount2 = parseInt((ev.target as HTMLInputElement).value);
+    const amount1 = entry.amount1 ?? 0;
+    this._editSchedule = { ...entry, amount2, amount: amount1 + amount2 };
   }
 
   renderSwitch() {
@@ -451,15 +487,34 @@ class DispenserScheduleCard extends LitElement {
             @value-changed=${(ev: CustomEvent) =>
               this.handleTimeChanged(ev, entry)}
           ></ha-time-input>
-          <ha-textfield
-            .value=${entry.amount}
-            type="number"
-            no-spinner
-            label=${this._config.unit_of_measurement ?? localize("ui.amount")}
-            max=${this._device.maxAmount}
-            min=${this._device.minAmount}
-            @change=${(ev: InputEvent) => this.handleAmountChanged(ev, entry)}
-          ></ha-textfield>
+          ${this._device.isDualHopper
+            ? html`<ha-textfield
+                .value=${entry.amount1 ?? Math.ceil(entry.amount / 2)}
+                type="number"
+                no-spinner
+                label="Hopper 1"
+                max=${this._device.maxAmount}
+                min=${this._device.minAmount}
+                @change=${(ev: InputEvent) => this.handleAmount1Changed(ev, entry)}
+              ></ha-textfield>
+              <ha-textfield
+                .value=${entry.amount2 ?? Math.floor(entry.amount / 2)}
+                type="number"
+                no-spinner
+                label="Hopper 2"
+                max=${this._device.maxAmount}
+                min=${this._device.minAmount}
+                @change=${(ev: InputEvent) => this.handleAmount2Changed(ev, entry)}
+              ></ha-textfield>`
+            : html`<ha-textfield
+                .value=${entry.amount}
+                type="number"
+                no-spinner
+                label=${this._config.unit_of_measurement ?? localize("ui.amount")}
+                max=${this._device.maxAmount}
+                min=${this._device.minAmount}
+                @change=${(ev: InputEvent) => this.handleAmountChanged(ev, entry)}
+              ></ha-textfield>`}
         </div>
         <div
           class="edit-row-spacer"

--- a/src/petkit-schedule-matrix-card.css
+++ b/src/petkit-schedule-matrix-card.css
@@ -1,0 +1,258 @@
+/* petkit-schedule-matrix-card styles */
+
+:host {
+  --tab-active-color: var(--primary-color, #03a9f4);
+  --tab-inactive-color: var(--disabled-text-color, #999);
+  --row-hover: var(--secondary-background-color, #f5f5f5);
+  --status-dispensed: var(--state-active-color, #4caf50);
+  --status-failed: var(--error-color, #f44336);
+  --status-pending: var(--primary-text-color, #333);
+  --status-skipped: var(--state-inactive-color, #9e9e9e);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 16px 8px;
+  font-size: 1.1em;
+  font-weight: 500;
+}
+
+.card-header .title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tab-bar {
+  display: flex;
+  gap: 2px;
+  padding: 0 12px 8px;
+  overflow-x: auto;
+}
+
+.tab-bar button {
+  flex: 1;
+  min-width: 40px;
+  padding: 6px 4px;
+  border: none;
+  border-radius: 8px;
+  background: var(--card-background-color, #fff);
+  color: var(--tab-inactive-color);
+  font-size: 0.8em;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1px solid var(--divider-color, #e0e0e0);
+}
+
+.tab-bar button.active {
+  background: var(--tab-active-color);
+  color: #fff;
+  border-color: var(--tab-active-color);
+}
+
+.tab-bar button:hover:not(.active) {
+  background: var(--row-hover);
+}
+
+.schedule-list {
+  padding: 0 8px 8px;
+}
+
+.schedule-row {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 8px;
+  transition: background 0.15s;
+  gap: 12px;
+}
+
+.schedule-row:hover {
+  background: var(--row-hover);
+}
+
+.schedule-row .time {
+  font-weight: 600;
+  font-size: 1em;
+  min-width: 50px;
+  font-variant-numeric: tabular-nums;
+}
+
+.schedule-row .amounts {
+  flex: 1;
+  display: flex;
+  gap: 8px;
+  font-size: 0.9em;
+}
+
+.schedule-row .amounts .hopper {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background: var(--secondary-background-color, #f0f0f0);
+  font-size: 0.85em;
+}
+
+.schedule-row .amounts .hopper.h1 {
+  color: var(--info-color, #2196f3);
+}
+
+.schedule-row .amounts .hopper.h2 {
+  color: var(--warning-color, #ff9800);
+}
+
+.schedule-row .status-icon {
+  display: flex;
+  align-items: center;
+}
+
+.schedule-row .status-icon ha-icon {
+  --mdc-icon-size: 18px;
+}
+
+.schedule-row .status-icon.dispensed { color: var(--status-dispensed); }
+.schedule-row .status-icon.failed { color: var(--status-failed); }
+.schedule-row .status-icon.pending { color: var(--status-pending); }
+.schedule-row .status-icon.skipped { color: var(--status-skipped); }
+
+.schedule-row .actions {
+  display: flex;
+  gap: 2px;
+}
+
+.schedule-row .actions ha-icon-button {
+  --mdc-icon-button-size: 32px;
+  --mdc-icon-size: 18px;
+}
+
+.empty-state {
+  text-align: center;
+  padding: 24px;
+  color: var(--secondary-text-color);
+  font-style: italic;
+}
+
+/* Edit form */
+.edit-form {
+  padding: 12px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: var(--secondary-background-color, #f5f5f5);
+  border-radius: 8px;
+  margin: 4px 8px;
+}
+
+.edit-form .edit-row {
+  display: flex;
+  gap: 8px;
+  align-items: flex-end;
+}
+
+.edit-form ha-textfield {
+  flex: 1;
+}
+
+.edit-form .edit-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+/* Bottom toolbar */
+.toolbar {
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px 12px;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.toolbar-left,
+.toolbar-right {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.toolbar mwc-button {
+  --mdc-typography-button-font-size: 0.85em;
+}
+
+/* Apply dialog overlay */
+.apply-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+}
+
+.apply-dialog {
+  background: var(--card-background-color, #fff);
+  border-radius: 16px;
+  padding: 20px;
+  min-width: 280px;
+  max-width: 90vw;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+}
+
+.apply-dialog h3 {
+  margin: 0 0 16px;
+  font-size: 1.1em;
+}
+
+.apply-dialog .day-checkboxes {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.apply-dialog .day-checkboxes label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  cursor: pointer;
+  padding: 4px 0;
+}
+
+.apply-dialog .day-checkboxes label.current {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.apply-dialog .dialog-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.suspended-badge {
+  font-size: 0.75em;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: var(--error-color, #f44336);
+  color: #fff;
+}
+
+.draft-badge {
+  font-size: 0.75em;
+  padding: 1px 6px;
+  border-radius: 8px;
+  background: var(--warning-color, #ff9800);
+  color: #fff;
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.6; }
+}

--- a/src/petkit-schedule-matrix-card.ts
+++ b/src/petkit-schedule-matrix-card.ts
@@ -1,0 +1,516 @@
+import { html, LitElement, nothing, unsafeCSS } from "lit";
+import { customElement } from "lit/decorators/custom-element.js";
+import styles from "./petkit-schedule-matrix-card.css";
+
+const DAY_LABELS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+const STATUS_MAP: Record<number, { icon: string; cls: string }> = {
+  0: { icon: "mdi:clock-outline", cls: "pending" },
+  1: { icon: "mdi:check", cls: "dispensed" },
+  2: { icon: "mdi:check", cls: "dispensed" },
+  3: { icon: "mdi:check", cls: "dispensed" },
+  6: { icon: "mdi:help-circle-outline", cls: "skipped" },
+  7: { icon: "mdi:close", cls: "failed" },
+  8: { icon: "mdi:clock-remove-outline", cls: "skipped" },
+  9: { icon: "mdi:alert-circle-outline", cls: "failed" },
+};
+
+interface FeedItem {
+  time: number;
+  name: string | null;
+  amount: number | null;
+  amount1: number | null;
+  amount2: number | null;
+  id: number | null;
+}
+
+interface DaySchedule {
+  repeats: string | number | null;
+  suspended: number | null;
+  count: number;
+  items: FeedItem[];
+}
+
+interface EditState {
+  dayIndex: number;
+  itemIndex: number | null; // null = adding new
+  hour: number;
+  minute: number;
+  amount1: number;
+  amount2: number;
+}
+
+interface CardConfig {
+  entity: string;
+  type: string;
+}
+
+@customElement("petkit-schedule-matrix-card")
+class PetkitScheduleMatrixCard extends LitElement {
+  declare _hass: any;
+  declare _config: CardConfig;
+  declare _activeDay: number;
+  declare _editState: EditState | null;
+  declare _showApplyDialog: boolean;
+  declare _applyDays: boolean[];
+  /** Local working copy of the schedule. null = no changes. */
+  declare _draft: DaySchedule[] | null;
+
+  static get properties() {
+    return {
+      _hass: { state: true },
+      _config: { state: true },
+      _activeDay: { state: true },
+      _editState: { state: true },
+      _showApplyDialog: { state: true },
+      _applyDays: { state: true },
+      _draft: { state: true },
+    };
+  }
+
+  static get styles() {
+    return unsafeCSS(styles);
+  }
+
+  constructor() {
+    super();
+    this._activeDay = 0;
+    this._editState = null;
+    this._showApplyDialog = false;
+    this._applyDays = [false, false, false, false, false, false, false];
+    this._draft = null;
+  }
+
+  set hass(hass: any) {
+    this._hass = hass;
+  }
+
+  setConfig(config: CardConfig) {
+    if (!config.entity) {
+      throw new Error("entity is required");
+    }
+    this._config = config;
+  }
+
+  getCardSize(): number {
+    return 5;
+  }
+
+  private get _entity(): any | undefined {
+    return this._hass?.states?.[this._config?.entity ?? ""];
+  }
+
+  /** Server schedule from entity attributes (read-only source of truth). */
+  private get _serverSchedule(): DaySchedule[] {
+    const fdl = this._entity?.attributes?.feed_daily_list;
+    if (!fdl || !Array.isArray(fdl)) return [];
+    return fdl;
+  }
+
+  /** Active schedule: draft if dirty, otherwise server. */
+  private get _schedule(): DaySchedule[] {
+    return this._draft ?? this._serverSchedule;
+  }
+
+  private get _hasDraft(): boolean {
+    return this._draft !== null;
+  }
+
+  private get _deviceId(): number | null {
+    return this._entity?.attributes?.device_id ?? null;
+  }
+
+  private get _currentDaySchedule(): DaySchedule | null {
+    return this._schedule[this._activeDay] ?? null;
+  }
+
+  /** Ensure _draft has a deep clone to mutate. */
+  private _ensureDraft(): DaySchedule[] {
+    if (!this._draft) {
+      this._draft = JSON.parse(JSON.stringify(this._serverSchedule));
+    }
+    return this._draft!;
+  }
+
+  // --- Status from state string ---
+  private _getStatusMap(): Map<number, number> {
+    const state = this._entity?.state ?? "";
+    const map = new Map<number, number>();
+    if (!state || state === "unknown" || state === "unavailable") return map;
+    const parts = state.split(",");
+    for (let i = 0; i + 4 < parts.length; i += 5) {
+      const timeSec = parseInt(parts[i + 1]) * 3600 + parseInt(parts[i + 2]) * 60;
+      const status = parseInt(parts[i + 4]);
+      map.set(timeSec, status);
+    }
+    return map;
+  }
+
+  // --- Rendering ---
+  render() {
+    if (!this._hass || !this._config) return nothing;
+
+    const entity = this._entity;
+    if (!entity) {
+      return html`<ha-card>
+        <div class="card-content">
+          <ha-alert alert-type="warning">Entity not found: ${this._config.entity}</ha-alert>
+        </div>
+      </ha-card>`;
+    }
+
+    return html`
+      <ha-card>
+        ${this._renderHeader()}
+        ${this._renderTabs()}
+        ${this._editState ? this._renderEditForm() : this._renderScheduleList()}
+        ${this._renderToolbar()}
+        ${this._showApplyDialog ? this._renderApplyDialog() : nothing}
+      </ha-card>
+    `;
+  }
+
+  private _renderHeader() {
+    const day = this._currentDaySchedule;
+    const isSuspended = day?.suspended === 1;
+    return html`
+      <div class="card-header">
+        <span class="title">
+          <ha-icon icon="mdi:calendar-clock"></ha-icon>
+          Feeding Schedule
+          ${isSuspended ? html`<span class="suspended-badge">Paused</span>` : nothing}
+          ${this._hasDraft ? html`<span class="draft-badge">Unsaved</span>` : nothing}
+        </span>
+      </div>
+    `;
+  }
+
+  private _renderTabs() {
+    return html`
+      <div class="tab-bar">
+        ${DAY_LABELS.map(
+          (label, i) => html`
+            <button
+              class=${this._activeDay === i ? "active" : ""}
+              @click=${() => this._setActiveDay(i)}
+            >
+              ${label}
+            </button>
+          `
+        )}
+      </div>
+    `;
+  }
+
+  private _renderScheduleList() {
+    const day = this._currentDaySchedule;
+    if (!day || !day.items || day.items.length === 0) {
+      return html`<div class="empty-state">No feeds scheduled for this day</div>`;
+    }
+
+    const statusMap = this._getStatusMap();
+
+    return html`
+      <div class="schedule-list">
+        ${day.items
+          .map((item, idx) => ({ item, idx }))
+          .sort((a, b) => (a.item.time ?? 0) - (b.item.time ?? 0))
+          .map(({ item, idx }) => this._renderScheduleRow(item, idx, statusMap))}
+      </div>
+    `;
+  }
+
+  private _renderScheduleRow(
+    item: FeedItem,
+    idx: number,
+    statusMap: Map<number, number>,
+  ) {
+    const t = item.time ?? 0;
+    const h = Math.floor(t / 3600);
+    const m = Math.floor((t % 3600) / 60);
+    const a1 = item.amount1 ?? 0;
+    const a2 = item.amount2 ?? 0;
+    const statusCode = statusMap.get(t) ?? 0;
+    const status = STATUS_MAP[statusCode] ?? STATUS_MAP[0];
+
+    return html`
+      <div class="schedule-row">
+        <span class="time">${h}:${m.toString().padStart(2, "0")}</span>
+        <div class="amounts">
+          <span class="hopper h1">H1: ${a1}</span>
+          <span class="hopper h2">H2: ${a2}</span>
+        </div>
+        <span class="status-icon ${status.cls}">
+          <ha-icon icon="${status.icon}"></ha-icon>
+        </span>
+        <div class="actions">
+          <ha-icon-button @click=${() => this._startEdit(idx)}>
+            <ha-icon icon="mdi:pencil"></ha-icon>
+          </ha-icon-button>
+          <ha-icon-button @click=${() => this._removeEntry(idx)}>
+            <ha-icon icon="mdi:delete"></ha-icon>
+          </ha-icon-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private _renderEditForm() {
+    const e = this._editState!;
+    return html`
+      <div class="edit-form">
+        <div class="edit-row">
+          <ha-textfield
+            .value=${e.hour}
+            type="number"
+            no-spinner
+            label="Hour"
+            min="0"
+            max="23"
+            @change=${(ev: InputEvent) => {
+              this._editState = { ...e, hour: parseInt((ev.target as HTMLInputElement).value) || 0 };
+            }}
+          ></ha-textfield>
+          <ha-textfield
+            .value=${e.minute}
+            type="number"
+            no-spinner
+            label="Min"
+            min="0"
+            max="59"
+            @change=${(ev: InputEvent) => {
+              this._editState = { ...e, minute: parseInt((ev.target as HTMLInputElement).value) || 0 };
+            }}
+          ></ha-textfield>
+          <ha-textfield
+            .value=${e.amount1}
+            type="number"
+            no-spinner
+            label="Hopper 1"
+            min="0"
+            max="50"
+            @change=${(ev: InputEvent) => {
+              this._editState = { ...e, amount1: parseInt((ev.target as HTMLInputElement).value) };
+            }}
+          ></ha-textfield>
+          <ha-textfield
+            .value=${e.amount2}
+            type="number"
+            no-spinner
+            label="Hopper 2"
+            min="0"
+            max="50"
+            @change=${(ev: InputEvent) => {
+              this._editState = { ...e, amount2: parseInt((ev.target as HTMLInputElement).value) };
+            }}
+          ></ha-textfield>
+        </div>
+        <div class="edit-actions">
+          <mwc-button @click=${() => (this._editState = null)}>Cancel</mwc-button>
+          <mwc-button raised @click=${() => this._saveEdit()}>OK</mwc-button>
+        </div>
+      </div>
+    `;
+  }
+
+  private _renderToolbar() {
+    if (this._editState) return nothing;
+    return html`
+      <div class="toolbar">
+        <div class="toolbar-left">
+          <mwc-button @click=${() => this._startAdd()}>
+            <ha-icon icon="mdi:clock-plus"></ha-icon>
+            Add
+          </mwc-button>
+          <mwc-button @click=${() => this._openApplyDialog()}>
+            <ha-icon icon="mdi:content-copy"></ha-icon>
+            Copy to days
+          </mwc-button>
+        </div>
+        ${this._hasDraft
+          ? html`<div class="toolbar-right">
+              <mwc-button @click=${() => this._discardDraft()}>
+                Discard
+              </mwc-button>
+              <mwc-button raised @click=${() => this._applyDraft()}>
+                <ha-icon icon="mdi:cloud-upload"></ha-icon>
+                Apply
+              </mwc-button>
+            </div>`
+          : nothing}
+      </div>
+    `;
+  }
+
+  private _renderApplyDialog() {
+    return html`
+      <div class="apply-overlay" @click=${(e: Event) => {
+        if ((e.target as HTMLElement).classList.contains("apply-overlay")) {
+          this._showApplyDialog = false;
+        }
+      }}>
+        <div class="apply-dialog">
+          <h3>Copy ${DAY_LABELS[this._activeDay]}'s schedule to:</h3>
+          <div class="day-checkboxes">
+            ${DAY_LABELS.map(
+              (label, i) => html`
+                <label class=${i === this._activeDay ? "current" : ""}>
+                  <input
+                    type="checkbox"
+                    ?checked=${this._applyDays[i]}
+                    ?disabled=${i === this._activeDay}
+                    @change=${(ev: Event) => {
+                      const checked = (ev.target as HTMLInputElement).checked;
+                      const newDays = [...this._applyDays];
+                      newDays[i] = checked;
+                      this._applyDays = newDays;
+                    }}
+                  />
+                  ${label} ${i === this._activeDay ? "(current)" : ""}
+                </label>
+              `
+            )}
+          </div>
+          <div class="dialog-actions">
+            <mwc-button @click=${() => (this._showApplyDialog = false)}>Cancel</mwc-button>
+            <mwc-button raised @click=${() => this._copyToSelectedDays()}>Copy</mwc-button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  // --- Actions (all mutate draft, never call API directly) ---
+  private _setActiveDay(day: number) {
+    this._activeDay = day;
+    this._editState = null;
+  }
+
+  private _startEdit(itemIndex: number) {
+    const day = this._currentDaySchedule;
+    if (!day) return;
+    const item = day.items[itemIndex];
+    if (!item) return;
+    const t = item.time ?? 0;
+    this._editState = {
+      dayIndex: this._activeDay,
+      itemIndex,
+      hour: Math.floor(t / 3600),
+      minute: Math.floor((t % 3600) / 60),
+      amount1: item.amount1 ?? 0,
+      amount2: item.amount2 ?? 0,
+    };
+  }
+
+  private _startAdd() {
+    this._editState = {
+      dayIndex: this._activeDay,
+      itemIndex: null,
+      hour: 0,
+      minute: 0,
+      amount1: 1,
+      amount2: 1,
+    };
+  }
+
+  /** Save edit to draft (no API call). */
+  private _saveEdit() {
+    const e = this._editState;
+    if (!e) return;
+    const draft = this._ensureDraft();
+
+    const timeInSeconds = e.hour * 3600 + e.minute * 60;
+    const newItem: FeedItem = {
+      time: timeInSeconds,
+      name: `Feed ${e.hour}:${e.minute.toString().padStart(2, "0")}`,
+      amount: null,
+      amount1: e.amount1,
+      amount2: e.amount2,
+      id: timeInSeconds,
+    };
+
+    const day = draft[e.dayIndex];
+    if (!day) return;
+
+    if (e.itemIndex === null) {
+      day.items.push(newItem);
+    } else {
+      day.items[e.itemIndex] = newItem;
+    }
+    day.count = day.items.length;
+
+    // Trigger re-render with new draft reference
+    this._draft = [...draft];
+    this._editState = null;
+  }
+
+  /** Remove entry from draft (no API call). */
+  private _removeEntry(itemIndex: number) {
+    const draft = this._ensureDraft();
+    const day = draft[this._activeDay];
+    if (!day) return;
+    day.items.splice(itemIndex, 1);
+    day.count = day.items.length;
+    this._draft = [...draft];
+  }
+
+  private _openApplyDialog() {
+    this._applyDays = DAY_LABELS.map((_, i) => i === this._activeDay);
+    this._showApplyDialog = true;
+  }
+
+  /** Copy current day's schedule to selected days in draft (no API call). */
+  private _copyToSelectedDays() {
+    const draft = this._ensureDraft();
+    const sourceDay = draft[this._activeDay];
+    if (!sourceDay) return;
+
+    for (let i = 0; i < this._applyDays.length; i++) {
+      if (this._applyDays[i] && i !== this._activeDay && draft[i]) {
+        draft[i].items = JSON.parse(JSON.stringify(sourceDay.items));
+        draft[i].count = sourceDay.items.length;
+      }
+    }
+
+    this._draft = [...draft];
+    this._showApplyDialog = false;
+  }
+
+  /** Discard all local changes, revert to server schedule. */
+  private _discardDraft() {
+    this._draft = null;
+    this._editState = null;
+  }
+
+  /** Send the draft to the API (the only point where API is called). */
+  private _applyDraft() {
+    if (!this._draft) return;
+    this._callSetSchedule(this._draft);
+    this._draft = null;
+  }
+
+  // --- API ---
+  private _callSetSchedule(schedule: DaySchedule[]) {
+    if (!this._deviceId) {
+      console.error("[PetkitMatrix] No device_id in entity attributes");
+      return;
+    }
+
+    const serviceData = {
+      device_id: this._deviceId,
+      feed_daily_list: schedule.map((day) => ({
+        repeats: day.repeats,
+        suspended: day.suspended ?? 0,
+        items: (day.items || []).map((item) => ({
+          time: item.time,
+          name: item.name,
+          amount: item.amount ?? 0,
+          amount1: item.amount1 ?? 0,
+          amount2: item.amount2 ?? 0,
+        })),
+      })),
+    };
+
+    this._hass.callService("petkit", "set_feeding_schedule", serviceData);
+  }
+}

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -22,6 +22,8 @@ export interface ScheduleEntry {
   hour: number;
   minute: number;
   amount: number;
+  amount1?: number;
+  amount2?: number;
   status: EntryStatus;
 }
 
@@ -30,6 +32,8 @@ export interface EditScheduleEntry {
   hour: number;
   minute: number;
   amount: number;
+  amount1?: number;
+  amount2?: number;
 }
 
 export abstract class Device {
@@ -38,10 +42,40 @@ export abstract class Device {
   abstract readonly minAmount: number;
   abstract readonly stepAmount: number;
 
+  /** Whether this device has dual hoppers (shows separate amount1/amount2). */
+  get isDualHopper(): boolean {
+    return false;
+  }
+
   constructor(
     readonly config: DispenserScheduleCardConfig,
     readonly hass: any
   ) {}
 
   abstract getSchedule(state: string): Array<ScheduleEntry>;
+
+  /**
+   * Handle saving an entry (add or edit). Return true if handled by the
+   * device implementation, false to fall back to per-entry service dispatch.
+   */
+  handleSave(
+    _hass: any,
+    _schedules: Array<ScheduleEntry>,
+    _entry: EditScheduleEntry,
+    _scheduleEntity: any,
+  ): boolean {
+    return false;
+  }
+
+  /**
+   * Handle removing an entry. Return true if handled, false to fall back.
+   */
+  handleRemove(
+    _hass: any,
+    _schedules: Array<ScheduleEntry>,
+    _entry: EditScheduleEntry,
+    _scheduleEntity: any,
+  ): boolean {
+    return false;
+  }
 }


### PR DESCRIPTION
## Summary
Adds PetKit device support to the dispenser-schedule-card and introduces a standalone schedule matrix card.

### PetkitDevice Handler
- Bulk-replace pattern for PetKit saveFeed API
- Per-hopper amount1/amount2 parsing from entity attributes
- isDualHopper getter on Device base class

### Schedule Matrix Card (standalone)
- 7-day tab navigation (Mon-Sun)
- Per-hopper display with color-coded badges (H1 blue, H2 orange)
- Inline editing with hour/minute/hopper inputs
- Batch-edit model: local mutations with single Apply button
- Copy-to-days dialog for bulk schedule duplication

### Config
\\\yaml
type: custom:petkit-schedule-matrix-card
entity: sensor.dual_hopper_with_camera_raw_distribution_data
\\\

### Dependencies
- Depends on: [homeassistant_petkit](https://github.com/Jezza34000/homeassistant_petkit) integration changes (sensor attributes)
- Depends on: [py-petkit-api#53](https://github.com/Jezza34000/py-petkit-api/pull/53) (SAVE_FEED command)